### PR TITLE
Add '--mirror' option to 'git clone'

### DIFF
--- a/lib/github-backup.rb
+++ b/lib/github-backup.rb
@@ -80,7 +80,7 @@ private ######################################################################
 
   def backup_repository_initial(repository)
     FileUtils::cd(backup_root) do
-      shell("git clone -n #{repository.clone_url}")
+      shell("git clone --mirror -n #{repository.clone_url}")
     end
   end
 


### PR DESCRIPTION
If we're making a complete backup of all repositories, might as well get all the refs.
