### PR TITLE
Use ssh_url rather than clone_url

### DIFF
--- a/lib/github-backup.rb
+++ b/lib/github-backup.rb
@@ -91,7 +91,7 @@ class Github::Backup
 
   def backup_repository_initial(repository)
     FileUtils::cd(backup_root) do
-      shell("git clone --mirror -n #{repository.clone_url}")
+      shell("git clone --mirror -n #{repository.ssh_url}")
     end
   end
 


### PR DESCRIPTION
Didn't spot this in #8, sorry!

clone_url seems to always return the HTTP URL so asks for authentication
for private repos.