### PR TITLE
Extract configuration from Backup

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -20,8 +20,8 @@ unless ARGV.length == 2
   exit 1
 end
 
-username = ARGV.shift
-root     = ARGV.shift
+username              = ARGV.shift
+options[:backup_root] = ARGV.shift
 
-backup = GithubBackup::Backup.new(username, root, options)
+backup = GithubBackup::Backup.new(username, options)
 backup.execute

--- a/lib/github-backup/backup.rb
+++ b/lib/github-backup/backup.rb
@@ -18,7 +18,7 @@ module GithubBackup
       puts "Or, use the arguments to authenticate with your username and API token."
     end
 
-    private ######################################################################
+    private
 
     def backup_root
       config.backup_root

--- a/lib/github-backup/config.rb
+++ b/lib/github-backup/config.rb
@@ -1,0 +1,47 @@
+module GithubBackup
+  class Config
+
+    DEFAULTS = {
+      :gitconfig_path => "#{ENV['HOME']}/.gitconfig",
+    }
+
+    attr_reader :backup_root, :gitconfig_path, :token
+
+    def initialize(options = {})
+      @backup_root    = options.fetch(:backup_root)    { raise ArgumentError, 'A backup_root option is required' }
+      @gitconfig_path = options.fetch(:gitconfig_path) { DEFAULTS[:gitconfig_path] }
+      @token          = options.fetch(:token)          { default_token }
+    end
+
+    private
+
+    def default_token
+      config = read_gitconfig
+      if config.key?('github')
+        config['github'].fetch('token', nil)
+      end
+    end
+
+    def read_gitconfig
+      config = {}
+      group = nil
+
+      return config unless File.exists?(gitconfig_path)
+
+      File.foreach(gitconfig_path) do |line|
+        line.strip!
+        if line[0] != ?# && line =~ /\S/
+          if line =~ /^\[(.*)\]$/
+            group = $1
+            config[group] ||= {}
+          else
+            key, value = line.split("=").map { |v| v.strip }
+            config[group][key] = value
+          end
+        end
+      end
+      config
+    end
+
+  end
+end


### PR DESCRIPTION
Requires #12 

Extracts the config in to `GithubBackup::Config`.

Probably deserves a bump to ~~`0.9.0`~~ `0.10.0` as the `backup_root` parameter has now been removed from `GithubBackup::Backup#initialize`