### PR TITLE
Use HTTPS URL instead of SSH URL

### DIFF
--- a/lib/github-backup/backup.rb
+++ b/lib/github-backup/backup.rb
@@ -73,7 +73,7 @@ module GithubBackup
 
     def backup_repository_initial(repository)
       FileUtils::cd(backup_root) do
-        shell("git clone --mirror -n #{repository.ssh_url} #{repository.full_name}.git")
+        shell("git clone --mirror -n #{repository.clone_url} #{repository.full_name}.git")
       end
     end
 


### PR DESCRIPTION
`https://github.com/my/repo.git` instead of `git@github.com:my/repo.git`

We don't want to access GitHub over SSH since it'd require a `~/.ssh/known_hosts` file and use our SSH key, etc. Moreover, it'd prompt the user to accept GitHub's fingerprint if it has never been accessed via SSH on the machine.

I think it makes more sense to clone repos over HTTPS.